### PR TITLE
add touch option support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ Using `counter_cache: true` on `belongs_to` associations also works as expected.
 ## Limitations / TODO
 
 - Add `reset_counters` implementation
-- Support `touch: *` option
 - Add `with_slotted_counters` scope
 - Add multiple `has_slotted_counter` support
 - Rails 6 support

--- a/spec/slotted_counter_spec.rb
+++ b/spec/slotted_counter_spec.rb
@@ -50,28 +50,6 @@ RSpec.describe "ActiveRecord::SlottedCounterCache", :db do
       expect(article.likes_count).to eq(likes_count)
       expect(article.comments_count).to eq(comments_count)
     end
-
-    # TODO move to shared_examples after adding touch support for slotted counter
-    it "must not update 'updated_at' without 'touch' option" do
-      article = WithSlottedCounter::Article.create!
-      previous_updated_at = article.updated_at
-
-      WithSlottedCounter::Article.update_counters(article.id, likes_count: 1)
-
-      article.reload
-      expect(article.updated_at).to eq(previous_updated_at)
-    end
-
-    # TODO move to shared_examples after adding touch support for slotted counter
-    it "must update 'updated_at' with 'touch' option" do
-      article = WithSlottedCounter::Article.create!
-      previous_updated_at = article.updated_at
-
-      WithSlottedCounter::Article.update_counters(article.id, likes_count: 1, touch: true)
-
-      article.reload
-      expect(article.updated_at).not_to eq(previous_updated_at)
-    end
   end
 
   describe "using slotted counter in child model" do

--- a/spec/support/active_record_init.rb
+++ b/spec/support/active_record_init.rb
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define do
     t.integer "comments_count", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "specific_updated_at"
   end
 
   create_table "with_native_counter_comments", force: :cascade do |t|
@@ -46,6 +47,7 @@ ActiveRecord::Schema.define do
   create_table "with_slotted_counter_articles", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "specific_updated_at"
     t.integer "likes_count", default: 0
   end
 

--- a/spec/support/shared_examples_for_cache_counters.rb
+++ b/spec/support/shared_examples_for_cache_counters.rb
@@ -43,5 +43,35 @@ RSpec.shared_examples "ActiveRecord::CounterCache interface" do |article_class, 
       expect(article.comments_count).to eq(1)
       expect(updated_rows_count).to eq(1)
     end
+
+    it "must not update 'updated_at' without 'touch' option" do
+      article = article_class.create!
+      previous_updated_at = article.updated_at
+
+      article_class.update_counters(article.id, comments_count: 1)
+
+      article.reload
+      expect(article.updated_at).to eq(previous_updated_at)
+    end
+
+    it "must update 'updated_at' with 'touch' option" do
+      article = article_class.create!
+      previous_updated_at = article.updated_at
+
+      article_class.update_counters(article.id, comments_count: 1, touch: true)
+
+      article.reload
+      expect(article.updated_at).not_to eq(previous_updated_at)
+    end
+
+    it "must update specific datetime field with 'touch' option" do
+      article = article_class.create!
+      previous_specific_updated_at = article.specific_updated_at
+
+      article_class.update_counters(article.id, comments_count: 1, touch: :specific_updated_at)
+
+      article.reload
+      expect(article.specific_updated_at).not_to eq(previous_specific_updated_at)
+    end
   end
 end


### PR DESCRIPTION
Added `touch` option support. It allows passing `true` or specific attributes like in the native counter - https://api.rubyonrails.org/classes/ActiveRecord/CounterCache/ClassMethods.html#method-i-update_counters

Insert in slotted_counter table and datetime attribute update by `touch` options works in one transaction.