### PR TITLE
fix scope working with multiple counters

### DIFF
--- a/lib/activerecord_slotted_counters/has_slotted_counter.rb
+++ b/lib/activerecord_slotted_counters/has_slotted_counter.rb
@@ -40,7 +40,10 @@ module ActiveRecordSlottedCounters
 
         has_many association_name, ->(model) { associated_records(counter_name, model.id, model.class.to_s) }, **SLOTTED_COUNTERS_ASSOCIATION_OPTIONS
 
-        scope :with_slotted_counters, ->(counter_type) { preload(association_name) }
+        scope :with_slotted_counters, ->(counter_type) do
+          association_name = slotted_counter_association_name(counter_type)
+          preload(association_name)
+        end
 
         _slotted_counters << counter_type
 

--- a/lib/activerecord_slotted_counters/railtie.rb
+++ b/lib/activerecord_slotted_counters/railtie.rb
@@ -10,6 +10,7 @@ module ActiveRecordSlottedCounters # :nodoc:
     initializer "extend ActiveRecord with  ActiveRecordSlottedCounters" do |_app|
       ActiveSupport.on_load(:active_record) do
         ActiveRecord::Base.include ActiveRecordSlottedCounters::HasSlottedCounter
+        ActiveRecord::Relation.include ActiveRecordSlottedCounters::Utils
         ActiveRecord::Associations::BelongsToAssociation.prepend ActiveRecordSlottedCounters::BelongsToAssociation
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ require "active_record"
 require "activerecord-slotted_counters"
 
 ActiveRecord::Base.include ActiveRecordSlottedCounters::HasSlottedCounter
+ActiveRecord::Relation.include ActiveRecordSlottedCounters::Utils
 ActiveRecord::Associations::BelongsToAssociation.prepend ActiveRecordSlottedCounters::BelongsToAssociation
 
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].sort.each { |f| require f }


### PR DESCRIPTION
Previous implementation preload associations for the last defined slotted counter when a model has multiple slotted counters.
I fixed that by defining `assocation_name` in the `with_slotted_counter` scope based on `counter_type`.