### PR TITLE
fix counter preloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+## 0.1.2 (2023-03-28)
+
+- Fix preloading counters for multiple records [#12](https://github.com/evilmartians/activerecord-slotted_counters/pull/12) ([@LukinEgor][])
+
 ## 0.1.1 (2023-01-17)
 
 - Fix prevent double increment/decrement of native counter caches [#10](https://github.com/evilmartians/activerecord-slotted_counters/pull/10) ([@danielwestendorf][])

--- a/activerecord-slotted_counters.gemspec
+++ b/activerecord-slotted_counters.gemspec
@@ -32,4 +32,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec", ">= 3.9"
   s.add_development_dependency "pg", ">= 1.4"
   s.add_development_dependency "sqlite3"
+  s.add_development_dependency "rspec-sqlimit"
 end

--- a/spec/slotted_counter_spec.rb
+++ b/spec/slotted_counter_spec.rb
@@ -116,6 +116,15 @@ RSpec.describe "ActiveRecord::SlottedCounterCache", :db do
     end
   end
 
+  it "does not generate N+1 queries" do
+    WithSlottedCounter::Article.create!
+    WithSlottedCounter::Article.create!
+
+    expect {
+      WithSlottedCounter::Article.all.with_slotted_counters(:comments).find_each { _1.comments_count }
+    }.not_to exceed_query_limit(2).with(/SELECT/)
+  end
+
   def insert_association_sql(association_class, article_id)
     association_table = association_class.arel_table
     foreign_key = association_class.reflections["article"].foreign_key

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ rescue LoadError
 end
 ENV["RAILS_ENV"] = "test"
 
+require "rspec-sqlimit"
 require "active_record"
 require "activerecord-slotted_counters"
 

--- a/spec/support/shared_examples_for_cache_counters.rb
+++ b/spec/support/shared_examples_for_cache_counters.rb
@@ -89,12 +89,11 @@ RSpec.shared_examples "ActiveRecord::CounterCache interface" do |article_class, 
       expect(article.views_count).to eq(1)
 
       View.create!(viewable: article)
-      expect(article.views_count).to eq(2)
+      expect(article.reload.views_count).to eq(2)
 
       article.views.destroy_all
 
-      article.reload
-      expect(article.views_count).to eq(0)
+      expect(article.reload.views_count).to eq(0)
     end
   end
 


### PR DESCRIPTION
## What is the purpose of this pull request?
  Fix preloading counters for multiple records.
  Fixes #11 

## What changes did you make?
- Removed id param from `associated_records` scope. It brakes the Rails preload mechanism (and it's useless in general).
- Refactored the `read_slotted_counter` method. We don't need to do branching because `load_target` does the same - loads from db if there are no cached records and loads from memory if there are.

## Checklist

- [X] I've added tests for this change
- [X] I've added a Changelog entry
