### PR TITLE
fix: don't mutate sql string in pg adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+## 0.1.4 (2023-04-19)
+
+- Fix "can't modify frozen String" for the pg adapter (ruby 2.7)  [#15](https://github.com/evilmartians/activerecord-slotted_counters/pull/15) ([@LukinEgor][])
+
 ## 0.1.3 (2023-04-03)
 
 - Add Rails 6 support (PostgreSQL only) [#13](https://github.com/evilmartians/activerecord-slotted_counters/pull/13) ([@LukinEgor][])

--- a/lib/activerecord_slotted_counters/adapters/pg_upsert.rb
+++ b/lib/activerecord_slotted_counters/adapters/pg_upsert.rb
@@ -37,14 +37,14 @@ module ActiveRecordSlottedCounters
           columns = columns_for_attributes(index.columns)
           fields = quote_column_names(columns)
 
-          sql << " ON CONFLICT (#{fields})"
+          sql += " ON CONFLICT (#{fields})"
         end
 
         if on_duplicate.present?
-          sql << " DO UPDATE SET #{on_duplicate}"
+          sql += " DO UPDATE SET #{on_duplicate}"
         end
 
-        sql << " RETURNING \"id\""
+        sql += " RETURNING \"id\""
 
         klass.connection.exec_query(sql)
       end


### PR DESCRIPTION
## What is the purpose of this pull request?

fixes the 'can\'t modify frozen String' problem for ruby2.7 in the pg adapter. https://github.com/evilmartians/activerecord-slotted_counters/actions/runs/4742349902/jobs/8420515040

## What changes did you make? (overview)

replaced << on += for creating a new SQL string object.

## Checklist

- [x] I've added a Changelog entry