### PR TITLE
Add mysql2 support

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         ruby: ["3.0"]
         gemfile: ["gemfiles/rails7.gemfile"]
-        db: ["mysql"]
+        db: ["postgres"]
         include:
         - ruby: "2.7"
           gemfile: "gemfiles/rails6.gemfile"
@@ -31,11 +31,11 @@ jobs:
         - ruby: "3.1"
           gemfile: "gemfiles/railsmaster.gemfile"
           db: "postgres"
-        - ruby: "3.0"
-          gemfile: "gemfiles/rails7.gemfile"
-          db: "postgres"
         - ruby: "2.7"
           gemfile: "gemfiles/rails6.gemfile"
+          db: "mysql"
+        - ruby: "3.0"
+          gemfile: "gemfiles/rails7.gemfile"
           db: "mysql"
         - ruby: "3.1"
           gemfile: "gemfiles/railsmaster.gemfile"
@@ -43,11 +43,11 @@ jobs:
         - ruby: "2.7"
           gemfile: "gemfiles/rails6.gemfile"
           db: "sqlite"
-        - ruby: "3.1"
-          gemfile: "gemfiles/railsmaster.gemfile"
-          db: "sqlite"
         - ruby: "3.0"
           gemfile: "gemfiles/rails7.gemfile"
+          db: "sqlite"
+        - ruby: "3.1"
+          gemfile: "gemfiles/railsmaster.gemfile"
           db: "sqlite"
     services:
       postgres:

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -14,6 +14,7 @@ jobs:
       BUNDLE_RETRY: 3
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
       POSTGRES_URL: postgres://postgres:postgres@localhost:5432
+      MYSQL_URL: mysql2://rails:rails@127.0.0.1:3306
       DB: ${{ matrix.db }}
       DB_NAME: slotted_counters_test
       CI: true
@@ -22,7 +23,7 @@ jobs:
       matrix:
         ruby: ["3.0"]
         gemfile: ["gemfiles/rails7.gemfile"]
-        db: ["sqlite"]
+        db: ["mysql"]
         include:
         - ruby: "2.7"
           gemfile: "gemfiles/rails6.gemfile"
@@ -35,9 +36,18 @@ jobs:
           db: "postgres"
         - ruby: "2.7"
           gemfile: "gemfiles/rails6.gemfile"
+          db: "mysql"
+        - ruby: "3.1"
+          gemfile: "gemfiles/railsmaster.gemfile"
+          db: "mysql"
+        - ruby: "2.7"
+          gemfile: "gemfiles/rails6.gemfile"
           db: "sqlite"
         - ruby: "3.1"
           gemfile: "gemfiles/railsmaster.gemfile"
+          db: "sqlite"
+        - ruby: "3.0"
+          gemfile: "gemfiles/rails7.gemfile"
           db: "sqlite"
     services:
       postgres:
@@ -47,6 +57,19 @@ jobs:
           POSTGRES_PASSWORD: postgres
         options: >-
           --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      mysql:
+        image: mysql:8
+        ports: [ "3306:3306" ]
+        env:
+          MYSQL_PASSWORD: rails
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: slotted_counters_test
+          MYSQL_USER: rails
+        options: >-
+          --health-cmd "mysqladmin ping"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Add Mysql support [#18](https://github.com/evilmartians/activerecord-slotted_counters/pull/18) ([@prog-supdex][])
+
 - Add SQLite support [#17](https://github.com/evilmartians/activerecord-slotted_counters/pull/17) ([@prog-supdex][])
 
 ## 0.1.4 (2023-04-19)

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Using `counter_cache: true` on `belongs_to` associations also works as expected.
 
 ## Limitations / TODO
 
-- Gem supports only PostgreSQL and SQLite3 for Rails 6
+- Gem supports only PostgreSQL, SQLite3 and MySQL for Rails 6
 
 ## Contributing
 

--- a/gemfiles/rails6.gemfile
+++ b/gemfiles/rails6.gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 6.0"
+gem "mysql2"
 
 gemspec path: ".."

--- a/gemfiles/rails7.gemfile
+++ b/gemfiles/rails7.gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 7.0"
+gem "mysql2"
 
 gemspec path: ".."

--- a/gemfiles/railsmaster.gemfile
+++ b/gemfiles/railsmaster.gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
 gem "rails", github: "rails/rails"
+gem "mysql2"
 
 gemspec path: ".."

--- a/lib/activerecord_slotted_counters/adapters/rails_upsert.rb
+++ b/lib/activerecord_slotted_counters/adapters/rails_upsert.rb
@@ -3,11 +3,10 @@
 module ActiveRecordSlottedCounters
   module Adapters
     class RailsUpsert
-      attr_reader :klass, :current_adapter_name
+      attr_reader :klass
 
-      def initialize(klass, current_adapter_name)
+      def initialize(klass)
         @klass = klass
-        @current_adapter_name = current_adapter_name
       end
 
       def apply?(_)

--- a/lib/activerecord_slotted_counters/adapters/rails_upsert.rb
+++ b/lib/activerecord_slotted_counters/adapters/rails_upsert.rb
@@ -3,10 +3,11 @@
 module ActiveRecordSlottedCounters
   module Adapters
     class RailsUpsert
-      attr_reader :klass
+      attr_reader :klass, :current_adapter_name
 
-      def initialize(klass)
+      def initialize(klass, current_adapter_name)
         @klass = klass
+        @current_adapter_name = current_adapter_name
       end
 
       def apply?(_)
@@ -14,7 +15,11 @@ module ActiveRecordSlottedCounters
       end
 
       def bulk_insert(attributes, on_duplicate: nil, unique_by: nil)
-        klass.upsert_all(attributes, on_duplicate: on_duplicate, unique_by: unique_by)
+        klass.upsert_all(attributes, on_duplicate: on_duplicate, unique_by: unique_by).rows.count
+      end
+
+      def wrap_column_name(value)
+        "EXCLUDED.#{value}"
       end
     end
   end

--- a/lib/activerecord_slotted_counters/adapters/sqlite_upsert.rb
+++ b/lib/activerecord_slotted_counters/adapters/sqlite_upsert.rb
@@ -49,7 +49,11 @@ module ActiveRecordSlottedCounters
 
         sql += " RETURNING \"id\""
 
-        klass.connection.exec_query(sql)
+        klass.connection.exec_query(sql).rows.count
+      end
+
+      def wrap_column_name(value)
+        "EXCLUDED.#{value}"
       end
 
       private

--- a/spec/support/active_record_init.rb
+++ b/spec/support/active_record_init.rb
@@ -1,9 +1,16 @@
 # frozen_string_literal: true
 
 DB_CONFIG =
-  if ENV["DB"] == "postgres"
+  if ENV["DB"] == "postgres" || ENV["DB"] == "mysql"
     require "active_record/database_configurations"
-    url = ENV.fetch("POSTGRES_URL")
+    url = ENV.fetch("DATABASE_URL") do
+      case ENV["DB"]
+      when "postgres"
+        ENV.fetch("POSTGRES_URL")
+      when "mysql"
+        ENV.fetch("MYSQL_URL")
+      end
+    end
 
     config = ActiveRecord::DatabaseConfigurations::UrlConfig.new(
       "test",

--- a/spec/support/shared_examples_for_cache_counters.rb
+++ b/spec/support/shared_examples_for_cache_counters.rb
@@ -38,7 +38,7 @@ RSpec.shared_examples "ActiveRecord::CounterCache interface" do |article_class, 
     end
 
     it "must not update 'updated_at' without 'touch' option" do
-      article = article_class.create!
+      article = article_class.create!(created_at: 1.minute.ago, updated_at: 1.minute.ago)
       previous_updated_at = article.reload.updated_at
 
       article_class.update_counters(article.id, comments_count: 1)
@@ -49,7 +49,7 @@ RSpec.shared_examples "ActiveRecord::CounterCache interface" do |article_class, 
 
     it "must update 'updated_at' with 'touch' option" do
       article = article_class.create!(created_at: 1.minute.ago, updated_at: 1.minute.ago)
-      previous_updated_at = article.updated_at
+      previous_updated_at = article.reload.updated_at
 
       article_class.update_counters(article.id, comments_count: 1, touch: true)
 

--- a/spec/support/shared_examples_for_cache_counters.rb
+++ b/spec/support/shared_examples_for_cache_counters.rb
@@ -48,8 +48,8 @@ RSpec.shared_examples "ActiveRecord::CounterCache interface" do |article_class, 
     end
 
     it "must update 'updated_at' with 'touch' option" do
-      article = article_class.create!
-      previous_updated_at = article.reload.updated_at
+      article = article_class.create!(created_at: 1.minute.ago, updated_at: 1.minute.ago)
+      previous_updated_at = article.updated_at
 
       article_class.update_counters(article.id, comments_count: 1, touch: true)
 


### PR DESCRIPTION
## What is the purpose of this pull request?
Added mysql2 support

## Is there anything you'd like reviewers to focus on?
Added a new Mysql Adapter
Mysql doesn't support `ON CONFLICT` (but has `ON DUPLICATE KEY UPDATE`) and doesn't have `RETURNING ID`

So, I used `ActiveRecord::Base.connection.update(sql)` for getting amount of updated rows
Also, Mysql doesn't understand `EXCLUDED`, so we need to use some method `wrap_column_name`, which will be defined in every adapter. Because, Mysql understands `VALUES(here_column_names)`, but Postgresql understands `EXCLUDED.here_column_name`

## Checklist

- [- ] I've added tests for this change
- [+] I've added a Changelog entry
- [+] I've updated a documentation
