### PR TITLE
change touch_attribute to be unscoped

### DIFF
--- a/lib/activerecord_slotted_counters/has_slotted_counter.rb
+++ b/lib/activerecord_slotted_counters/has_slotted_counter.rb
@@ -224,7 +224,7 @@ module ActiveRecordSlottedCounters
       end
 
       def touch_attributes(ids, touch)
-        scope = where(id: ids)
+        scope = unscoped.where(id: ids)
         return scope.touch_all if touch == true
 
         scope.touch_all(touch)

--- a/spec/slotted_counter_spec.rb
+++ b/spec/slotted_counter_spec.rb
@@ -144,4 +144,21 @@ RSpec.describe "ActiveRecord::SlottedCounterCache", :db do
 
     insert_manager.to_sql
   end
+
+  it "uses unscoped Active Record lookups when touch:true is used" do
+    article = WithSlottedCounter::DefaultScope.create!
+    expect(article.published).to be true
+    sql_output = []
+
+    ActiveSupport::Notifications.subscribe("sql.active_record") do |_, _, _, _, details|
+      sql_output << details[:sql]
+    end
+
+    WithSlottedCounter::DefaultScope.update_counters(article.id, comments_count: 1, touch: true)
+
+    ActiveSupport::Notifications.unsubscribe("sql.active_record")
+    expect(sql_output.any? { |sql| sql.include?("published = true") }).to be_falsey
+  end
+
+
 end

--- a/spec/support/models/with_slotted_counter/default_scope.rb
+++ b/spec/support/models/with_slotted_counter/default_scope.rb
@@ -1,0 +1,7 @@
+module WithSlottedCounter
+  class DefaultScope < Article
+    self.table_name = "with_slotted_counter_articles"
+    default_scope { where(published: true) }
+    attribute :published, :boolean, default: false
+  end
+end


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

## What is the purpose of this pull request?

Change the `touch:true` argument to `update_counters` to be unscoped, similar to ActiveRecord
<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->

## What changes did you make? (overview)


calling `update_counters` with `touch:true` keeps default scope

If you have a model with a default_scope such as:

`default_scope -> { where(active: true).order("items.created_at DESC, items.id DESC") }`

And then run a simple update_counters call like:

`Item.update_counters(33, quantity_count: 0, touch: true)`

the result SQL keeps the default scope on the touch:

 
>UPDATE items SET items.updated_at = '2025-03-04 14:03:58' WHERE items.active = TRUE AND items.id = 33 ORDER BY items.created_at DESC, items.id


I imagine its pretty unusual to want an ORDER BY in a simple update call.

I propose we change the `touch_attributes` method to use `unscoped`, which is similar to what [ActiveRecord does on their counter_cache implementation](https://github.com/rails/rails/blob/33beb0a38db1c058123a8e3cc298cad918adfe32/activerecord/lib/active_record/counter_cache.rb#L117)


My proposed change would change the SQL output to 


 >UPDATE items SET items.updated_at = '2025-03-04 14:11:40' WHERE items.id = 33


## Is there anything you'd like reviewers to focus on?

## Checklist

- [x] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated a documentation
